### PR TITLE
fix: getting started wording

### DIFF
--- a/developers/products/interchain-messaging-agent/getting-started.adoc
+++ b/developers/products/interchain-messaging-agent/getting-started.adoc
@@ -25,4 +25,4 @@ Deposits and withdraws take only seconds, and are secured using BLS Threshold si
 
 * The SKALE Chain contracts "LockAndData.." must be assigned the minter role for your modified token contract. This enables IMA to mint token clones as the tokens are Locked on mainnet contracts.
 
-* When using ERC721s, be careful with *MINT_ID*. This the the mapping between Mainnet and SKALE Chain ERC721s. Improper or corrupt mapping may cause loss of ERC721.
+* When using ERC721s, be careful with *MINT_ID*. This is the mapping between Mainnet and SKALE Chain ERC721s. Improper or corrupt mapping may cause loss of ERC721.


### PR DESCRIPTION
This PR fixes wording "the the" in the ima getting started doc

link for reference
https://skale.network/docs/developers/products/interchain-messaging-agent/getting-started